### PR TITLE
feat(api): refactorizar CI/CD con GraalVM y actualizar API

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,12 +1,9 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+# This workflow builds two Docker images in parallel:
+# 1. A standard JVM image.
+# 2. A GraalVM native image.
+# It then pushes both to a container registry.
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: ETEREA.isolate-service CI
+name: ETEREA.isolate-service Build JVM and GraalVM Native Images
 
 on:
   push:
@@ -15,33 +12,129 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-    if: github.ref == 'refs/heads/main'
+  build-and-analyze:
+    name: Build and Analyze with SonarCloud
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history for all branches and tags.
+          # SonarCloud needs this to perform analysis on PRs.
+          fetch-depth: 0
       - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
           java-version: '24'
           distribution: 'temurin'
-          cache: maven
-
-      - name: Build with Maven
-        run: mvn -B verify -DskipTests
-
-      - name: Set VERSION environment variable
-        id: version
-        run: echo "VERSION=v$(date +'%Y.%m.%d')-build${{ github.run_number }}" >> $GITHUB_ENV
-
-      - name: Build & push Docker image
-        uses: mr-smithers-excellent/docker-build-push@v6
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
         with:
-          image: ${{ secrets.DOCKER_IMAGE_NAME }}
-          tags: ${{ env.VERSION }}, latest, "${GITHUB_REF#refs/heads/}.$(git rev-parse --short ${GITHUB_SHA})"
-          registry: docker.io
-          dockerfile: Dockerfile
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and analyze
+        env:
+          # This token is stored in GitHub Secrets.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ETEREA-services_ETEREA.isolate-service
+
+  # --- Job 1: Build the standard JVM image ---
+  build-jvm-image:
+    # Only run on pushes to the main branch
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata for JVM Docker image
+        id: meta-jvm
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_IMAGE_NAME }}
+          # Add a '-jvm' suffix to tags to differentiate them
+          tags: |
+            type=semver,pattern={{version}},suffix=-jvm
+            type=semver,pattern={{major}}.{{minor}},suffix=-jvm
+            type=sha,suffix=-jvm
+            latest-jvm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push JVM Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # Point to the new JVM-specific Dockerfile
+          file: ./Dockerfile.jvm
+          push: true
+          tags: ${{ steps.meta-jvm.outputs.tags }}
+          labels: ${{ steps.meta-jvm.outputs.labels }}
+          cache-from: type=gha,scope=jvm
+          cache-to: type=gha,scope=jvm,mode=max
+
+  # --- Job 2: Build the GraalVM native image ---
+  build-native-image:
+    # Only run on pushes to the main branch
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata for Native Docker image
+        id: meta-native
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_IMAGE_NAME }}
+          # Use standard tags for the native image
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Native Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # Point to your GraalVM Dockerfile
+          file: ./Dockerfile.graalvm
+          push: true
+          tags: ${{ steps.meta-native.outputs.tags }}
+          labels: ${{ steps.meta-native.outputs.labels }}
+          cache-from: type=gha,scope=native
+          cache-to: type=gha,scope=native,mode=max

--- a/Dockerfile.graalvm
+++ b/Dockerfile.graalvm
@@ -23,7 +23,7 @@ RUN groupadd --system appgroup && useradd --system --gid appgroup --shell /bin/f
 USER appuser
 
 # Copiar el ejecutable nativo desde la etapa de compilación
-COPY --from=build /app/target/eterea.isolate-service /eterea.isolate-service
+COPY --from=build /app/target/eterea.programa-dia-service /eterea.programa-dia-service
 
 # Comando de entrada para ejecutar la aplicación
-ENTRYPOINT ["/eterea.isolate-service"]
+ENTRYPOINT ["/eterea.programa-dia-service"]

--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,0 +1,38 @@
+# Etapa 1: Compilación con Maven y JDK
+# Usamos una imagen oficial que contiene Maven y Java (Temurin)
+FROM maven:3-eclipse-temurin-24-alpine AS build
+
+# Establecemos el directorio de trabajo
+WORKDIR /app
+
+# Copiamos solo el pom.xml para aprovechar la caché de Docker
+# Si las dependencias no cambian, esta capa no se reconstruye
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copiamos el resto del código fuente
+COPY src ./src
+
+# Compilamos la aplicación y generamos el JAR, omitiendo los tests
+RUN mvn clean package
+
+
+# Etapa 2: Creación de la imagen final y ligera
+# Usamos una imagen solo con el JRE, que es más pequeña
+FROM eclipse-temurin:24-jre-alpine
+
+# Creamos un usuario y grupo no privilegiados por seguridad
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Establecemos el directorio de trabajo
+WORKDIR /app
+
+# Copiamos el JAR generado desde la etapa de compilación
+# El pom.xml define <finalName>eterea.import-service</finalName>
+COPY --from=build /app/target/eterea.import-service.jar ./eterea.import-service.jar
+
+# Cambiamos al usuario no privilegiado
+USER appuser
+
+# Comando para ejecutar la aplicación
+ENTRYPOINT ["java", "-jar", "eterea.import-service.jar"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,7 +3,7 @@ ENV HOME=/usr/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 ADD . $HOME
-RUN --mount=type=cache,target=/root/.m2 mvn -f $HOME/pom.xml clean package -DskipTests
+RUN --mount=type=cache,target=/root/.m2 mvn -f $HOME/pom.xml clean package
 
 FROM eclipse-temurin:24-jre-alpine
 
@@ -11,4 +11,4 @@ FROM eclipse-temurin:24-jre-alpine
 RUN apk update && apk add curl
 
 COPY --from=build /usr/app/target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","--enable-native-access=ALL-UNNAMED","-jar","/app.jar"]

--- a/src/main/java/eterea/isolate/service/client/core/facade/TransaccionFacturaProgramaDiaClient.java
+++ b/src/main/java/eterea/isolate/service/client/core/facade/TransaccionFacturaProgramaDiaClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "core-service/api/core/transaccion-factura-programa-dia")
 public interface TransaccionFacturaProgramaDiaClient {
 
-    @PostMapping("/registro/{orderNumberId}/dry-run/{dryRun}")
-    void registroTransaccionFacturaProgramaDia(@PathVariable Long orderNumberId, @PathVariable Boolean dryRun, @RequestBody FacturacionDto facturacionDto);
+    @PostMapping("/registro/{orderNumberId}/solo-factura/{soloFactura}/dry-run/{dryRun}")
+    void registroTransaccionFacturaProgramaDia(@PathVariable Long orderNumberId, @PathVariable Boolean soloFactura, @PathVariable Boolean dryRun, @RequestBody FacturacionDto facturacionDto);
 
 }

--- a/src/main/java/eterea/isolate/service/controller/RellenadorController.java
+++ b/src/main/java/eterea/isolate/service/controller/RellenadorController.java
@@ -23,9 +23,9 @@ public class RellenadorController {
         return ResponseEntity.ok(service.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante));
     }
 
-    @GetMapping("/autoCompleta/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/dry-run/{dryRun}")
-    public ResponseEntity<Void> autoCompleta(@PathVariable Integer tipoAfipId, @PathVariable Integer puntoVenta, @PathVariable Long numeroComprobante, @PathVariable Boolean dryRun) {
-        service.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, dryRun);
+    @GetMapping("/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/solo-factura/{soloFactura}/dry-run/{dryRun}")
+    public ResponseEntity<Void> autoCompleta(@PathVariable Integer tipoAfipId, @PathVariable Integer puntoVenta, @PathVariable Long numeroComprobante, @PathVariable Boolean soloFactura, @PathVariable Boolean dryRun) {
+        service.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, soloFactura, dryRun);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/eterea/isolate/service/service/RellenadorService.java
+++ b/src/main/java/eterea/isolate/service/service/RellenadorService.java
@@ -33,7 +33,7 @@ public class RellenadorService {
         return facturadorClient.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
     }
 
-    public void autoCompleta(Integer tipoAfipId, Integer puntoVenta, Long numeroComprobante, Boolean dryRun) {
+    public void autoCompleta(Integer tipoAfipId, Integer puntoVenta, Long numeroComprobante, Boolean soloFactura, Boolean dryRun) {
         var facturaArca = facturadorClient.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
         logFacturaArca(facturaArca);
         try {
@@ -50,7 +50,12 @@ public class RellenadorService {
             log.debug("Error. Importe ARCA diferente OrderNote");
             return;
         }
-        transaccionFacturaProgramaDiaClient.registroTransaccionFacturaProgramaDia(orderNote.getOrderNumberId(), dryRun, FacturacionAdapter.toFacturacionDto(facturaArca));
+        transaccionFacturaProgramaDiaClient.registroTransaccionFacturaProgramaDia(
+                orderNote.getOrderNumberId(),
+                soloFactura,
+                dryRun,
+                FacturacionAdapter.toFacturacionDto(facturaArca)
+        );
     }
 
     private void logOrderNote(OrderNoteDto orderNote) {


### PR DESCRIPTION
## Descripción
Este PR introduce una refactorización completa del pipeline de CI/CD para soportar compilaciones nativas con GraalVM junto a las de JVM estándar. Además, actualiza la API principal para mejorar la consistencia y añade una nueva funcionalidad de filtrado.

Este trabajo cierra el issue #11.

## Cambios Realizados
- [x] **CI/CD con GraalVM:** Se ha modificado `.github/workflows/maven.yml` para construir y publicar dos imágenes Docker en paralelo: una para JVM y otra nativa con GraalVM.
- [x] **Integración con SonarCloud:** Se ha añadido un paso en el workflow para el análisis estático de código con SonarCloud.
- [x] **Actualización de API (Breaking Change):** Se ha renombrado el endpoint `/autoCompleta` a `/auto-completa` en `RellenadorController` para seguir las convenciones de nombres de endpoints.
- [x] **Nueva Funcionalidad de Filtrado:** Se ha añadido el parámetro booleano `soloFactura` al endpoint `/auto-completa` para permitir filtrar transacciones que sean únicamente facturas.
- [x] **Dockerfiles Específicos:** Se han creado `Dockerfile.jvm` y `Dockerfile.graalvm` para gestionar las particularidades de cada pipeline de construcción.

## Impacto Potencial
- [x] **Breaking Change:** Cualquier cliente que consuma el endpoint `/autoCompleta` deberá actualizar la URL a `/auto-completa`.
- [ ] No se requieren cambios en variables de entorno ni migraciones de base de datos.

## Verificación
*Un revisor puede verificar los cambios siguiendo estos pasos:*
1.  `git checkout 11-feat-refactorización-de-cicd-con-graalvm-y-actualización-de-api`
2.  `./mvnw clean install`
3.  Ejecutar la aplicación: `java -jar target/isolate-service-*.jar`
4.  Verificar el cambio de nombre del endpoint y la nueva funcionalidad. Puedes usar `curl`:
    *   **Endpoint actualizado (debería funcionar):**
        ```bash
        curl "http://localhost:8080/auto-completa?query=...&soloFactura=true"
        ```
    *   **Endpoint antiguo (debería fallar):**
        ```bash
        curl "http://localhost:8080/autoCompleta?query=..."
        ```
5.  Revisar el workflow de GitHub Actions para confirmar que los pasos de build y publicación de imágenes son correctos.

## Notas Adicionales
La decisión de usar dos Dockerfiles separados (`Dockerfile.jvm` y `Dockerfile.graalvm`) se tomó para mantener la legibilidad y facilitar el mantenimiento de cada pipeline de construcción, en lugar de usar un único Dockerfile con lógica condicional compleja.
