### PR TITLE
feat(api): Spring Boot 4.1.0, Java 25, breaking API, CI/CD overhaul

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -257,14 +257,10 @@ jobs:
             git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
-      - name: Prepare artifact for deployment
-        run: |
-          mkdir -p _site
-          mv docs/* _site/
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: _site
+          path: docs
 
   deploy-pages:
     needs: generate-docs
@@ -279,4 +275,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,3 @@
-# This workflow builds two Docker images in parallel:
-# 1. A standard JVM image.
-# 2. A GraalVM native image.
-# It then pushes both to a container registry.
 
 name: ETEREA.isolate-service Build JVM and GraalVM Native Images
 
@@ -17,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -48,7 +44,7 @@ jobs:
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ETEREA-services_ETEREA.isolate-service
 
   # --- Job 1: Build the standard JVM image ---
-  build-jvm-image:
+  build-image:
     # Only run on pushes to the main branch
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -58,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -79,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-28
+### Added
+- feat(endpoint): Nuevo parámetro `comprobanteId` en endpoint `auto-completa` para especificar el comprobante a buscar (Fuente: `git diff HEAD`, `RellenadorController.java`)
+- feat(deps): Nueva dependencia `spring-boot-starter-webmvc-test` para tests de WebMvc (Fuente: `git diff HEAD`, `pom.xml`)
+- feat(deps): Nueva dependencia `commons-fileupload` 1.6.0 en `dependencyManagement` (Fuente: `git diff HEAD`, `pom.xml`)
+- feat(refactor): Uso de `@RequiredArgsConstructor` de Lombok en `RellenadorService`, eliminando constructor explícito (Fuente: `git diff HEAD`, `RellenadorService.java`)
+- feat(ci): Unificación de jobs de build de imágenes JVM (`build-jvm-image` → `build-image`) (Fuente: `git diff HEAD`, `maven.yml`)
+
+### Changed
+- chore(deps): Migración de Spring Boot 3.5.6 a 4.1.0 (Fuente: `git diff HEAD`, `pom.xml`)
+- chore(deps): Actualización de Java 24 a 25 (Fuente: `git diff HEAD`, `pom.xml`, `Dockerfile`)
+- chore(deps): Actualización de Spring Cloud 2025.0.0 a 2025.1.2 (Fuente: `git diff HEAD`, `pom.xml`)
+- chore(deps): Actualización de SpringDoc OpenAPI 2.8.10 a 3.0.3 (Fuente: `git diff HEAD`, `pom.xml`)
+- chore(deps): Actualización de commons-lang3 3.18.0 a 3.20.0 (Fuente: `git diff HEAD`, `pom.xml`)
+- chore(deps): Actualización de imágenes Docker a Eclipse Temurin 25 (Fuente: `git diff HEAD`, `Dockerfile`)
+- chore(deps): Actualización de Actions en CI/CD (checkout v6, setup-java v5, cache v5, docker/login v4, docker/metadata v6, docker/setup-buildx v4, docker/build-push v7, upload-pages-artifact v4, deploy-pages v5) (Fuente: `git diff HEAD`, `.github/workflows/*.yml`)
+- chore(config): Eliminada configuración `executable=true` del plugin spring-boot-maven-plugin (Fuente: `git diff HEAD`, `pom.xml`)
+- fix(dto): Cambio de formato de fecha `Z` a `XX` en DTOs (`ArticuloMovimientoDto`, `ClienteDto`, `ClienteMovimientoDto`) para compatibilidad con Java 25 (Fuente: `git diff HEAD`)
+- chore(ci): Simplificación del pipeline de generación de documentación, eliminando el directorio `_site` intermedio (Fuente: `git diff HEAD`, `generate-docs.yml`)
+- chore(test): Actualización de import en `RellenadorControllerTest` para `spring-boot-webmvc-test` (Fuente: `git diff HEAD`)
+
+### Removed
+- chore(ci): Eliminado job de build de imagen nativa GraalVM (Fuente: `git diff HEAD`, `maven.yml`)
+
 ## [0.6.1] - 2025-09-21
 ### Changed
 - chore(deps): Actualización de Spring Boot a 3.5.6.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Eterea Isolate Service
 
-![Java](https://img.shields.io/badge/java-24-blue.svg)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen.svg)
-![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-yellow.svg)
+![Java](https://img.shields.io/badge/java-25-blue.svg)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg)
+![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-yellow.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/com.termascacheuta/eterea-isolate-service.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.termascacheuta%22%20AND%20a:%22eterea-isolate-service%22)
 
-## Novedades en la versión 0.6.1
+## Novedades en la versión 0.7.0
 
-- **Actualización de Dependencias:** Mejora en la estabilidad y compatibilidad con Spring Boot 3.5.6 y SpringDoc OpenAPI 2.8.10.
+- **Migración a Spring Boot 4.1.0 y Java 25:** Actualización mayor del framework base y la plataforma Java.
+- **Breaking API:** Nuevo parámetro `comprobanteId` en endpoint `auto-completa` para especificar el comprobante a buscar.
+- **Actualización de Dependencias:** Spring Cloud 2025.1.2, SpringDoc OpenAPI 3.0.3, commons-lang3 3.20.0.
+- **Simplificación CI/CD:** Eliminado job de build de imagen nativa GraalVM; imágenes Docker actualizadas a Eclipse Temurin 25.
 
 ## Overview
 Eterea Isolate Service is a lightweight, standalone Spring Boot microservice designed to run occasional or specific processes on the Eterea ecosystem without requiring a full redeployment of the main services.
@@ -23,10 +26,9 @@ This approach allows for greater flexibility and agility when performing mainten
 - **API Documentation**: Provides clear API documentation through OpenAPI.
 
 ## Technical Stack
-...existing code...
-- Java 24
-- Spring Boot 3.5.6
-- Spring Cloud 2025.0.0
+- Java 25
+- Spring Boot 4.1.0
+- Spring Cloud 2025.1.2
 - Spring Cloud Consul Discovery
 - Spring Cloud OpenFeign
 - Lombok
@@ -42,30 +44,41 @@ src/main/java/eterea/isolate/service/
 │   ├── core/
 │   │   ├── ArticuloClient.java
 │   │   ├── ClienteMovimientoClient.java
+│   │   ├── ComprobanteClient.java
 │   │   └── facade/
 │   │       ├── FacturacionClient.java
 │   │       └── TransaccionFacturaProgramaDiaClient.java
-│   └── pyafipws/
-│       └── FacturadorClient.java
+│   ├── pyafipws/
+│   │   └── FacturadorClient.java
+│   └── web/
+│       └── OrderNoteClient.java
 ├── configuration/
+│   ├── FeignAuthInterceptor.java
 │   └── IsolateServiceConfiguration.java
-├── controller/ 
-│   └── RellenadorController.java 
-├── model/ 
-│   └── dto/ 
+├── controller/
+│   ├── NotaCreditoController.java
+│   └── RellenadorController.java
+├── model/
+│   └── dto/
 │       ├── core/
 │       │   └── FacturacionDto.java
 │       ├── web/
-│       │   └── ProductDto.java
-│       ├── ArticuloDto.java 
-│       ├── ArticuloMovimientoDto.java 
-│       ├── ClienteDto.java 
-│       ├── ClienteMovimientoDto.java 
-│       ├── ComprobanteDto.java 
-│       ├── CuentaDto.java 
-│       ├── DatoUnaFacturaDto.java 
-│       └── FacturaResponseDto.java 
+│       │   ├── InformacionPagadorDto.java
+│       │   ├── OrderNoteDto.java
+│       │   ├── PaymentDto.java
+│       │   ├── ProductDto.java
+│       │   └── ProductTransactionDto.java
+│       ├── ArticuloDto.java
+│       ├── ArticuloMovimientoDto.java
+│       ├── ClienteDto.java
+│       ├── ClienteMovimientoDto.java
+│       ├── ComprobanteDto.java
+│       ├── CuentaDto.java
+│       ├── DatoUnaFacturaDto.java
+│       ├── MonedaDto.java
+│       └── FacturaResponseDto.java
 ├── service/
+│   ├── NotaCreditoService.java
 │   ├── RellenadorService.java
 │   └── miscelaneos/
 │       └── ToolService.java
@@ -73,7 +86,7 @@ src/main/java/eterea/isolate/service/
 ```
 
 ## Configuration
-The service is configured through `bootstrap.yml` with the following key properties:
+The service is configured through `application.yml` with the following key properties:
 - Server port: Configurable via `APP_PORT` environment variable (default: 8080)
 - Consul client configuration for service discovery
 - Logging levels
@@ -90,10 +103,21 @@ The service is configured through `bootstrap.yml` with the following key propert
   - `numeroComprobanteDesde`: Starting invoice number
   - `numeroComprobanteHasta`: Ending invoice number
 
+- **Endpoint**: `/api/isolate/rellenador/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/comprobante/{comprobanteId}/solo-factura/{soloFactura}/dry-run/{dryRun}`
+- **Method**: GET
+- **Description**: Auto-completes invoice information for a given comprobante
+- **Parameters**:
+  - `tipoAfipId`: AFIP document type ID
+  - `puntoVenta`: Sales point ID
+  - `numeroComprobante`: Invoice number
+  - `comprobanteId`: Comprobante ID to search for
+  - `soloFactura`: If true, only process invoices
+  - `dryRun`: If true, run without persisting changes
+
 ## Building and Running
 
 ### Prerequisites
-- JDK 24
+- JDK 25
 - Maven 3.9.9 or later
 - Docker (optional, for containerized deployment)
 

--- a/docs/diagrams/data-model.mmd
+++ b/docs/diagrams/data-model.mmd
@@ -1,9 +1,3 @@
-    class ProductDto {
-        +Long productId
-        +String name
-        +BigDecimal price
-        +String description
-    }
 classDiagram
     class DatoUnaFacturaDto {
         +ClienteMovimientoDto clienteMovimiento

--- a/docs/diagrams/sequence-flow.mmd
+++ b/docs/diagrams/sequence-flow.mmd
@@ -1,17 +1,3 @@
-
-    participant NotaCreditoController
-    participant NotaCreditoService
-    participant ComprobanteClient
-    participant FacturacionClient
-
-    User->>NotaCreditoController: GET /api/isolate/nota-credito/from/factura/{...}/nota/credito/{...}
-    NotaCreditoController->>NotaCreditoService: generateNotaCredito(...)
-    NotaCreditoService->>ClienteMovimientoClient: findByFactura(...)
-    NotaCreditoService->>ComprobanteClient: findByComprobanteId(...)
-    NotaCreditoService->>FacturacionClient: registroNotaCreditoFromFactura(...)
-    FacturacionClient-->>NotaCreditoService: ClienteMovimientoDto
-    NotaCreditoService-->>NotaCreditoController: ClienteMovimientoDto
-    NotaCreditoController-->>User: ResponseEntity(OK)
 sequenceDiagram
     participant User
     participant RellenadorController
@@ -20,6 +6,10 @@ sequenceDiagram
     participant ClienteMovimientoClient
     participant OrderNoteClient
     participant TransaccionFacturaProgramaDiaClient
+    participant NotaCreditoController
+    participant NotaCreditoService
+    participant ComprobanteClient
+    participant FacturacionClient
 
     User->>RellenadorController: GET /api/isolate/rellenador/auto-completa/{...}
     RellenadorController->>RellenadorService: autoCompleta(...)
@@ -39,3 +29,12 @@ sequenceDiagram
     end
     RellenadorService-->>RellenadorController: void
     RellenadorController-->>User: ResponseEntity(OK)
+
+    User->>NotaCreditoController: GET /api/isolate/nota-credito/from/factura/{...}/nota/credito/{...}
+    NotaCreditoController->>NotaCreditoService: generateNotaCredito(...)
+    NotaCreditoService->>ClienteMovimientoClient: findByFactura(...)
+    NotaCreditoService->>ComprobanteClient: findByComprobanteId(...)
+    NotaCreditoService->>FacturacionClient: registroNotaCreditoFromFactura(...)
+    FacturacionClient-->>NotaCreditoService: ClienteMovimientoDto
+    NotaCreditoService-->>NotaCreditoController: ClienteMovimientoDto
+    NotaCreditoController-->>User: ResponseEntity(OK)

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea-isolate-service</artifactId>
-    <version>0.6.1</version>
+    <version>0.7.0</version>
     <name>ETEREA.isolate-service</name>
     <description>eterea.isolate-service</description>
     <url/>
@@ -27,12 +27,12 @@
         <url/>
     </scm>
     <properties>
-        <java.version>24</java.version>
+        <java.version>25</java.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.isolate-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -87,6 +87,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -94,7 +99,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -108,6 +113,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -117,9 +127,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/eterea/isolate/service/controller/RellenadorController.java
+++ b/src/main/java/eterea/isolate/service/controller/RellenadorController.java
@@ -23,9 +23,9 @@ public class RellenadorController {
         return ResponseEntity.ok(service.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante));
     }
 
-    @GetMapping("/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/solo-factura/{soloFactura}/dry-run/{dryRun}")
-    public ResponseEntity<Void> autoCompleta(@PathVariable Integer tipoAfipId, @PathVariable Integer puntoVenta, @PathVariable Long numeroComprobante, @PathVariable Boolean soloFactura, @PathVariable Boolean dryRun) {
-        service.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, soloFactura, dryRun);
+    @GetMapping("/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/comprobante/{comprobanteId}/solo-factura/{soloFactura}/dry-run/{dryRun}")
+    public ResponseEntity<Void> autoCompleta(@PathVariable Integer tipoAfipId, @PathVariable Integer puntoVenta, @PathVariable Long numeroComprobante, @PathVariable Integer comprobanteId, @PathVariable Boolean soloFactura, @PathVariable Boolean dryRun) {
+        service.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, comprobanteId, soloFactura, dryRun);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/eterea/isolate/service/model/dto/ArticuloMovimientoDto.java
+++ b/src/main/java/eterea/isolate/service/model/dto/ArticuloMovimientoDto.java
@@ -37,10 +37,10 @@ public class ArticuloMovimientoDto {
     private Byte iva105 = 0;
     private Byte exento = 0;
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaMovimiento;
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaFactura;
     
     private Integer nivel = 0;

--- a/src/main/java/eterea/isolate/service/model/dto/ClienteDto.java
+++ b/src/main/java/eterea/isolate/service/model/dto/ClienteDto.java
@@ -15,7 +15,7 @@ public class ClienteDto {
     private String razonSocial = "";
     private String nombreFantasia = "";
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaRestaurant;
     
     private Integer cantidadPaxs = 0;

--- a/src/main/java/eterea/isolate/service/model/dto/ClienteMovimientoDto.java
+++ b/src/main/java/eterea/isolate/service/model/dto/ClienteMovimientoDto.java
@@ -22,12 +22,12 @@ public class ClienteMovimientoDto {
     private Integer puntoVenta = 0;
     private long numeroComprobante = 0L;
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaComprobante;
     
     private Long clienteId;
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimiento;
     
     private Integer negocioId;
@@ -40,7 +40,7 @@ public class ClienteMovimientoDto {
     private BigDecimal montoIvaRni = BigDecimal.ZERO;
     private BigDecimal reintegroTurista = BigDecimal.ZERO;
     
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaContable;
     
     private Integer ordenContable = 0;

--- a/src/main/java/eterea/isolate/service/service/RellenadorService.java
+++ b/src/main/java/eterea/isolate/service/service/RellenadorService.java
@@ -10,11 +10,13 @@ import eterea.isolate.service.client.web.OrderNoteClient;
 import eterea.isolate.service.model.dto.ClienteMovimientoDto;
 import eterea.isolate.service.model.dto.FacturaResponseDto;
 import eterea.isolate.service.model.dto.web.OrderNoteDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class RellenadorService {
 
     private final FacturadorClient facturadorClient;
@@ -22,23 +24,16 @@ public class RellenadorService {
     private final OrderNoteClient orderNoteClient;
     private final TransaccionFacturaProgramaDiaClient transaccionFacturaProgramaDiaClient;
 
-    public RellenadorService(FacturadorClient facturadorClient, ClienteMovimientoClient clienteMovimientoClient, OrderNoteClient orderNoteClient, TransaccionFacturaProgramaDiaClient transaccionFacturaProgramaDiaClient) {
-        this.facturadorClient = facturadorClient;
-        this.clienteMovimientoClient = clienteMovimientoClient;
-        this.orderNoteClient = orderNoteClient;
-        this.transaccionFacturaProgramaDiaClient = transaccionFacturaProgramaDiaClient;
-    }
-
     public FacturaResponseDto consultaComprobante(Integer tipoAfipId, Integer puntoVenta, Long numeroComprobante) {
         return facturadorClient.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
     }
 
-    public void autoCompleta(Integer tipoAfipId, Integer puntoVenta, Long numeroComprobante, Boolean soloFactura, Boolean dryRun) {
+    public void autoCompleta(Integer tipoAfipId, Integer puntoVenta, Long numeroComprobante, Integer comprobanteId, Boolean soloFactura, Boolean dryRun) {
         log.debug("Processing RellenadorService.autoCompleta");
         var facturaArca = facturadorClient.consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
         log.debug("FacturaArca -> {}", facturaArca.jsonify());
         try {
-            var clienteMovimiento = clienteMovimientoClient.findByComprobante(853, puntoVenta, numeroComprobante);
+            var clienteMovimiento = clienteMovimientoClient.findByComprobante(comprobanteId, puntoVenta, numeroComprobante);
             log.debug("ClienteMovimiento -> {}", clienteMovimiento.jsonify());
             log.debug("\n\n\nError. Comprobante encontrado\n\n\n");
             return;

--- a/src/test/java/eterea/isolate/service/controller/RellenadorControllerTest.java
+++ b/src/test/java/eterea/isolate/service/controller/RellenadorControllerTest.java
@@ -4,7 +4,7 @@ import eterea.isolate.service.model.dto.FacturaResponseDto;
 import eterea.isolate.service.service.RellenadorService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
Closes #25

## Descripción

Migración mayor del proyecto: Spring Boot 3.5.6 → 4.1.0, Java 24 → 25, actualización integral de dependencias, breaking change en API REST y simplificación del pipeline CI/CD.

## Cambios Realizados

- **Breaking API**: Nuevo path parameter `comprobanteId` en endpoint `auto-completa` (`/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/comprobante/{comprobanteId}/solo-factura/{soloFactura}/dry-run/{dryRun}`). Reemplazado valor hardcodeado `853` por parámetro dinámico.
- **Migración Spring Boot**: 3.5.6 → 4.1.0, con eliminación de `executable=true` (deprecado en SB 4.x).
- **Actualización Java**: 24 → 25. Cambio de formato de fecha `Z` → `XX` en 3 DTOs para compatibilidad con Java 25.
- **Actualización Spring Cloud**: 2025.0.0 → 2025.1.2.
- **Actualización dependencias**: SpringDoc OpenAPI 2.8.10 → 3.0.3, commons-lang3 3.18.0 → 3.20.0.
- **Nuevas dependencias**: `spring-boot-starter-webmvc-test` (test), `commons-fileupload:1.6.0`.
- **CI/CD**: Actualización de 10 GitHub Actions a sus últimas versiones, eliminación del job de build de imagen nativa GraalVM, unificación de `build-jvm-image` → `build-image`, simplificación del pipeline de documentación (eliminado directorio `_site` intermedio).
- **Refactor**: `RellenadorService` con `@RequiredArgsConstructor` de Lombok, eliminando constructor explícito.
- **Docker**: Imágenes base actualizadas a Eclipse Temurin 25.
- **Documentación**: README.md, CHANGELOG.md y diagramas actualizados para v0.7.0.

## Verificación

- [ ] Compilación con JDK 25: `mvn clean compile`
- [ ] Tests: `mvn test`
- [ ] Validar que el endpoint `auto-completa` funciona con el nuevo parámetro `comprobanteId`
- [ ] Verificar que el formato de fechas `XX` es compatible con Java 25
- [ ] Confirmar pipeline CI/CD en GitHub Actions
