### PR TITLE
fix(test): corrige valor hardcodeado de comprobanteId y actualiza documentación

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-06-28
+### Fixed
+- fix(test): Corregido valor hardcodeado de `comprobanteId` en tests de `RellenadorController` y `RellenadorService` (cambiado de `853` a `1`) (Fuente: `git diff HEAD`, `RellenadorControllerTest.java`, `RellenadorServiceTest.java`)
+
 ## [0.7.0] - 2026-06-28
 ### Added
 - feat(endpoint): Nuevo parámetro `comprobanteId` en endpoint `auto-completa` para especificar el comprobante a buscar (Fuente: `git diff HEAD`, `RellenadorController.java`)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 ![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-yellow.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/com.termascacheuta/eterea-isolate-service.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.termascacheuta%22%20AND%20a:%22eterea-isolate-service%22)
 
+## Novedades en la versión 0.7.1
+
+- **Corrección en tests:** Valor hardcodeado de `comprobanteId` corregido de `853` a `1` en pruebas de `RellenadorController` y `RellenadorService`.
+
 ## Novedades en la versión 0.7.0
 
 - **Migración a Spring Boot 4.1.0 y Java 25:** Actualización mayor del framework base y la plataforma Java.

--- a/docs/diagrams/architecture.mmd
+++ b/docs/diagrams/architecture.mmd
@@ -10,6 +10,7 @@ graph TD
         E[import-service/api/import/orderNote]
         F[core-service/api/core/transaccionFacturaProgramaDia]
         I[core-service/api/core/comprobante]
+        J[core-service/api/core/facturacion]
     end
 
     B --> C
@@ -18,7 +19,7 @@ graph TD
     B --> F
     H --> D
     H --> I
-    H --> F
+    H --> J
 
     style A fill:#f9f,stroke:#333,stroke-width:2px
     style B fill:#ccf,stroke:#333,stroke-width:2px
@@ -29,3 +30,4 @@ graph TD
     style E fill:#9cf,stroke:#333,stroke-width:2px
     style F fill:#9cf,stroke:#333,stroke-width:2px
     style I fill:#9cf,stroke:#333,stroke-width:2px
+    style J fill:#9cf,stroke:#333,stroke-width:2px

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea-isolate-service</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <name>ETEREA.isolate-service</name>
     <description>eterea.isolate-service</description>
     <url/>

--- a/src/test/java/eterea/isolate/service/controller/RellenadorControllerTest.java
+++ b/src/test/java/eterea/isolate/service/controller/RellenadorControllerTest.java
@@ -59,14 +59,15 @@ class RellenadorControllerTest {
         Integer tipoAfipId = 6;
         Integer puntoVenta = 5;
         Long numeroComprobante = 4L;
+        Integer comprobanteId = 1;
         Boolean soloFactura = false;
         Boolean dryRun = true;
 
         // When & Then
-        mockMvc.perform(get("/api/isolate/rellenador/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/solo-factura/{soloFactura}/dry-run/{dryRun}",
-                        tipoAfipId, puntoVenta, numeroComprobante, soloFactura, dryRun))
+        mockMvc.perform(get("/api/isolate/rellenador/auto-completa/{tipoAfipId}/{puntoVenta}/{numeroComprobante}/comprobante/{comprobanteId}/solo-factura/{soloFactura}/dry-run/{dryRun}",
+                        tipoAfipId, puntoVenta, numeroComprobante, comprobanteId, soloFactura, dryRun))
                 .andExpect(status().isOk());
 
-        verify(service).autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, soloFactura, dryRun);
+        verify(service).autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, comprobanteId, soloFactura, dryRun);
     }
 }

--- a/src/test/java/eterea/isolate/service/service/RellenadorServiceTest.java
+++ b/src/test/java/eterea/isolate/service/service/RellenadorServiceTest.java
@@ -74,11 +74,11 @@ class RellenadorServiceTest {
         doNothing().when(transaccionFacturaProgramaDiaClient).registroTransaccionFacturaProgramaDia(anyLong(), anyBoolean(), anyBoolean(), any());
 
         // When
-        rellenadorService.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, false, false);
+        rellenadorService.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, 1, false, false);
 
         // Then
         verify(facturadorClient).consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
-        verify(clienteMovimientoClient).findByComprobante(853, puntoVenta, numeroComprobante);
+        verify(clienteMovimientoClient).findByComprobante(1, puntoVenta, numeroComprobante);
         verify(orderNoteClient).findLastByNumeroDocumentoAndImporte(nroDoc, amount);
         verify(transaccionFacturaProgramaDiaClient).registroTransaccionFacturaProgramaDia(eq(1L), eq(false), eq(false), any(eterea.isolate.service.model.dto.core.FacturacionDto.class));
     }
@@ -107,11 +107,11 @@ class RellenadorServiceTest {
         when(orderNoteClient.findLastByNumeroDocumentoAndImporte(nroDoc, facturaArca.getFactura().getImpTotal())).thenReturn(orderNote);
 
         // When
-        rellenadorService.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, false, false);
+        rellenadorService.autoCompleta(tipoAfipId, puntoVenta, numeroComprobante, 1, false, false);
 
         // Then
         verify(facturadorClient).consultaComprobante(tipoAfipId, puntoVenta, numeroComprobante);
-        verify(clienteMovimientoClient).findByComprobante(853, puntoVenta, numeroComprobante);
+        verify(clienteMovimientoClient).findByComprobante(1, puntoVenta, numeroComprobante);
         verify(orderNoteClient).findLastByNumeroDocumentoAndImporte(nroDoc, facturaArca.getFactura().getImpTotal());
         verifyNoInteractions(transaccionFacturaProgramaDiaClient);
     }


### PR DESCRIPTION
Closes #27

## Descripción

Parche **v0.7.1** que corrige un valor hardcodeado incorrecto (`853` → `1`) en los tests unitarios de `RellenadorController` y `RellenadorService`, y actualiza la documentación (changelog, readme y diagrama de arquitectura).

## Cambios Realizados

- **fix(test):** Corregido `comprobanteId` de `853` a `1` en `RellenadorServiceTest.java`
- **fix(test):** Agregado parámetro `comprobanteId` en la URL del test de `RellenadorControllerTest.java`
- **docs:** Actualizado `CHANGELOG.md` con entrada para v0.7.1
- **docs:** Actualizado `README.md` con sección de novedades v0.7.1
- **docs:** Actualizado `docs/diagrams/architecture.mmd` (nuevo endpoint `/api/core/facturacion`)
- **chore:** Versión en `pom.xml` incrementada de `0.7.0` a `0.7.1`

## Verificación

- Los tests unitarios existentes se han actualizado con los valores correctos
- No hay cambios en código de producción
- Breaking changes: Ninguno
